### PR TITLE
Renamed braces.tst -> skew.tst, added 2 test cases.

### DIFF
--- a/tst/skew.tst
+++ b/tst/skew.tst
@@ -1,10 +1,14 @@
 #############################################################################
 ##
-##  braces.tst             YangBaxter package               Leandro Vendramin
+##  skew.tst               YangBaxter package               Leandro Vendramin
 ##
-gap> START_TEST("Example package: testall.tst");
+gap> START_TEST("skew.tst");
+gap> List([2..10],NrSmallSkewBraces);
+[ 1, 1, 4, 1, 6, 1, 47, 4, 6 ]
 gap> br:=SmallSkewBrace(8,1);
 A skew brace of size 8
+gap> Size(br);
+8
 gap> CategoriesOfObject(br);
 [ "IsSkewBrace" ]
 gap> SkewBraceAGroup(br);
@@ -13,7 +17,7 @@ Group([ (), (1,7,4,5,2,8,3,6), (1,4,2,3)(5,8,6,7), (1,2)(3,4)(5,6)(7,8), (1,5,3,
 gap> SkewBraceMGroup(br);
 Group([ (), (1,5,4,8,2,6,3,7), (1,3,2,4)(5,7,6,8), (1,2)(3,4)(5,6)(7,8), (1,7,3,6,
 2,8,4,5), (1,4,2,3)(5,8,6,7), (1,6,4,7,2,5,3,8), (1,8,3,5,2,7,4,6) ])
-gap> STOP_TEST( "braces.tst", 1 );
+gap> STOP_TEST( "skew.tst", 1 );
 
 #############################################################################
 ##


### PR DESCRIPTION
Having a test file named after the source code file being tested
is a useful convention. Also test Size and NrSmallSkewBraces
(to be extended later after fixing #5).