### PR TITLE
Fixing IsIdeal and IsLeftIdeal

### DIFF
--- a/lib/ideals.gi
+++ b/lib/ideals.gi
@@ -5,7 +5,9 @@ function(obj, subset)
 
   if IsSkewBrace(subset) then
     if HasParent(subset) and Parent(subset) = obj then
-      return true;
+      if HasIsIdealInParent(subset) then
+        return IsIdealInParent(subset);
+      fi;
     fi;
   fi;
 
@@ -31,7 +33,11 @@ function(obj, subset)
 
   if IsSkewBrace(subset) then
     if HasParent(subset) and Parent(subset) = obj then
-      return true;
+      if HasIsIdealInParent(subset) then
+        return IsIdealInParent(subset);
+      elif HasIsLeftIdealInParent(subset) then
+        return IsLeftIdealInParent(subset);
+      fi;
     fi;
   fi;
 

--- a/tst/testinstall/ideals.tst
+++ b/tst/testinstall/ideals.tst
@@ -31,7 +31,10 @@ gap> for k in [1..NrSmallSkewBraces(8)] do
 > br := SmallSkewBrace(8,k);
 > soc := Socle(br);
 > if not IsIdeal(br, soc) then
-> Print("This is wrong!\n");
+>   Print("This is wrong!\n");
+> fi;
+> if not IsLeftIdeal(br, soc) then
+>   Print("This is wrong!\n");
 > fi;
 > od;
 


### PR DESCRIPTION
Before the fix, it was returning `true` for any substructure of a brace.

This is an alternative fix for #34 