### PR TITLE
[WIP] Recomputation of NrSkewBraces based on definitions.

### DIFF
--- a/database/braces.g
+++ b/database/braces.g
@@ -1,0 +1,70 @@
+IsRegularSubgroup := function( HolA, H )
+local A, a, count, h, f, x;
+A := Image( Embedding( HolA, 2 ) );
+for a in A do
+  count:=0;
+  for h in H do
+    # h=(f,x) as an element of the semidirect product.
+    # We can do f := h^Projection(HolA);
+    # But how to find x?
+    # Why the line below is equivalent to IsOne(x*Image(f,a)) where h=(f,x) ?
+    if h * a in Image( Embedding(HolA, 1) ) then
+      # note that Image( Embedding(HolA, 1) ) is AutG as a subgroup of HolA
+      # h*a  = (f,x)(1,a) = (f, xf(a)) is in AutG iff xf(a)=1
+      count := count+1;
+    fi;
+    if count > 1 then
+      return false;
+    fi;  
+  od;
+  if count = 0 then 
+    return false;
+  fi;  
+od;
+return true;
+end;
+
+
+NrBracesOverGroup := function( G )
+
+local nr, HolA, AutA, A, phi, PermHolA, PermAutA, PermA,
+ccn, flat, orbs, orb, rep, a, fx;
+
+if not IsAbelian( G ) then
+  Error("The group G must be abelian!\n");
+fi;
+
+nr:=0;
+
+HolA := SemidirectProduct( AutomorphismGroup(G), G );
+AutA := Image( Embedding( HolA, 1 ) );
+A    := Image( Embedding( HolA, 2 ) );
+
+phi      := IsomorphismPermGroup( HolA );
+PermHolA := Image( phi);
+PermAutA := Image( phi, AutA );
+PermA    := Image( phi,A );
+  
+ccn:=Filtered(ConjugacyClassesSubgroups( PermHolA ), c -> Size(Representative(c)) = Size( A ) );
+  
+flat:=Concatenation(List(ccn,AsList));
+  
+orbs := Orbits( PermAutA, flat );
+  
+for orb in orbs do
+  for rep in orb do
+     if rep in flat and IsRegularSubgroup( HolA, PreImage( phi, rep ) ) then
+        nr := nr + 1;
+     fi;
+     break;
+   od;
+od;
+
+return nr;
+
+end;
+
+
+NrBracesFromScratch:=function(n)
+return Sum( List( AllSmallGroups(n, IsAbelian), NrBracesOverGroup ) );
+end;


### PR DESCRIPTION
See "Skew braces and the Yang-Baxter equation"
by L. Guarnieri, L. Vendramin for definitions
(https://arxiv.org/abs/1511.03171)

For example:
```
gap> for i in [2..15] do 
> Print(i,":",NrSmallBraces(i),":\c");
> Print(NrBracesFromScratch(i),":\n");
> od;
2:1:1:
3:1:1:
4:4:4:
5:1:1:
6:2:2:
7:1:1:
8:27:27:
9:4:4:
10:2:2:
11:1:1:
12:10:10:
13:1:1:
14:2:2:
15:1:1:
```

This is work in progress - I plan to incorporate into testing to calculate some numbers of braces "on fly" and compare with the stored ones.