### PR TITLE
Made some tests more robust

### DIFF
--- a/tst/testextra/example24.tst
+++ b/tst/testextra/example24.tst
@@ -20,7 +20,8 @@ gap> for k in [1..NrSmallBraces(8)] do
 > od;
 gap> l;
 [ 5 ]
-gap> ideals := Ideals(br);;
+gap> ideals := ShallowCopy(Ideals(br));;
+gap> SortBy(ideals,Size);
 gap> List(ideals, IdBrace);
 [ [ 1, 1 ], [ 2, 1 ], [ 4, 1 ], [ 8, 5 ] ]
 gap> List(ideals, x->IdBrace(br/x));

--- a/tst/testextra/example25.tst
+++ b/tst/testextra/example25.tst
@@ -1,11 +1,7 @@
 # Example 2.5
 gap> br := SmallBrace(6,2);;
-gap> List(LeftIdeals(br), IdBrace);
-[ [ 1, 1 ], [ 2, 1 ], [ 3, 1 ], [ 6, 2 ] ]
-gap> add := UnderlyingAdditiveGroup(br);
-Group([ (1,5,3,4,2,6) ])
-gap> mul := UnderlyingMultiplicativeGroup(br);
-Group([ (1,5,3,4,2,6) ])
+gap> add := UnderlyingAdditiveGroup(br);;
+gap> mul := UnderlyingMultiplicativeGroup(br);;
 gap> IdGroup(add);
 [ 6, 2 ]
 gap> IdGroup(mul);
@@ -24,7 +20,8 @@ gap> for k in [1..NrSmallBraces(6)] do
 > od;
 gap> l;
 [ 2 ]
-gap> left_ideals := LeftIdeals(br);;
+gap> left_ideals := ShallowCopy(LeftIdeals(br));;
+gap> SortBy(left_ideals,Size);
 gap> List(left_ideals, IdBrace);
 [ [ 1, 1 ], [ 2, 1 ], [ 3, 1 ], [ 6, 2 ] ]
 gap> List(left_ideals, x->IsIdeal(br, x));

--- a/tst/testextra/example26.tst
+++ b/tst/testextra/example26.tst
@@ -12,10 +12,11 @@ gap> IdGroup(add);
 [ 6, 2 ]
 gap> IdGroup(mul);
 [ 6, 1 ]
-gap> LeftIdeals(br);
+gap> left_ideals := ShallowCopy(LeftIdeals(br));;
+gap> SortBy(left_ideals,Size);
+gap> left_ideals;
 [ <brace of size 1>, <brace of size 2>, <brace of size 3>, <brace of size 6> ]
-gap> List(last, x->IsIdeal(br, x));
+gap> List(left_ideals, x->IsIdeal(br, x));
 [ true, false, true, true ]
-gap> Ideals(br);
-[ <brace of size 1>, <brace of size 3>, <brace of size 6> ]
-
+gap> SortedList(List(Ideals(br),Size));
+[ 1, 3, 6 ]

--- a/tst/testextra/example27.tst
+++ b/tst/testextra/example27.tst
@@ -1,7 +1,7 @@
 # Example 3.7
 gap> br := SmallBrace(8,18);;
 gap> ideals := Ideals(br);;
-gap> List(ideals, IdBrace);
+gap> SortedList(List(ideals, IdBrace));
 [ [ 1, 1 ], [ 4, 3 ], [ 8, 18 ] ]
 gap> Star(AsIdeal(br, br), ideals[2]);
 [ <()>, <(1,2)(3,4)(5,6)(7,8)> ]

--- a/tst/testextra/example32.tst
+++ b/tst/testextra/example32.tst
@@ -1,10 +1,10 @@
 # Example 3.2
 gap> br := SmallBrace(16,73);;
 gap> ideals := Ideals(br);;
-gap> List(ideals, IdBrace);
-[ [ 1, 1 ], [ 2, 1 ], [ 4, 2 ], [ 4, 1 ], [ 4, 3 ], [ 8, 13 ], [ 8, 10 ], 
+gap> SortedList(List(ideals, IdBrace));
+[ [ 1, 1 ], [ 2, 1 ], [ 4, 1 ], [ 4, 2 ], [ 4, 3 ], [ 8, 10 ], [ 8, 13 ], 
   [ 8, 19 ], [ 16, 73 ] ]
-gap> x := ideals[7];;
+gap> x := ideals[ PositionProperty( [ 1.. Length(ideals)], i -> IdBrace(ideals[i])=[8,10]) ];;
 gap> Star(x, x);
 [ <()>, <( 1, 2)( 3, 4)( 5, 6)( 7, 8)( 9,10)(11,12)(13,14)(15,16)> ]
 gap> IsIdeal(br, last);

--- a/tst/testinstall/ideals.tst
+++ b/tst/testinstall/ideals.tst
@@ -40,8 +40,8 @@ gap> for k in [1..NrSmallSkewbraces(8)] do
 
 # Test quotients 
 gap> br := SmallSkewbrace(16,300);;
-gap> List(Ideals(br), x->Size(Quotient(br, x)));
-[ 16, 8, 8, 8, 4, 2, 2, 2, 1 ]
+gap> SortedList(List(Ideals(br), x->Size(Quotient(br, x))));
+[ 1, 2, 2, 2, 4, 8, 8, 8, 16 ]
 
 # Test LeftSeries and IsLeftIdeal
 gap> br := SmallSkewbrace(36,191);;


### PR DESCRIPTION
Ordering of ideals depends on whether GAP is started without or with default packages. Used sorting to fix the ordering.