### PR TITLE
Fix ordering and titles of chapters and sections

### DIFF
--- a/doc/chapters.autodoc
+++ b/doc/chapters.autodoc
@@ -1,0 +1,5 @@
+@Chapter Preliminaries
+
+@Chapter Algebraic Properties of Braces
+
+@Chapter Ideals and Left Ideals

--- a/lib/radical.gd
+++ b/lib/radical.gd
@@ -1,3 +1,5 @@
+#! @Chapter Algebraic Properties of Braces
+#! @Section Braces and Radical Rings
 #! @Arguments ring
 #! @Returns a group 
 #! @Description

--- a/lib/ybe.gd
+++ b/lib/ybe.gd
@@ -1,3 +1,6 @@
+#! @Chapter Algebraic Properties of Braces
+#! @Section Braces and Yang-Baxter Equation
+
 DeclareCategory("IsYB", IsAttributeStoringRep);
 DeclareGlobalVariable("YBType");
 

--- a/makedoc.g
+++ b/makedoc.g
@@ -49,7 +49,9 @@ od;
 end;
 
 LoadPackage("AutoDoc");
-AutoDoc(rec(autodoc := true, scaffold:=true));
+AutoDoc( rec( scaffold :=true,
+              autodoc  := rec( files := [ "doc/chapters.autodoc" ] )
+));
 QUIT;
 ###########################################################################
 ##


### PR DESCRIPTION
The new TOC looks like this:

1 Preliminaries
1.1 Definition and examples
2 Algebraic Properties of Braces
2.1 Braces and Radical Rings
2.2 Braces and Yang-Baxter Equation
3 Ideals and left ideals
3.1 Left ideals
3.2 Ideals
3.3 Sequences (left) ideals
3.4 Mutipermutation skew braces
3.5 Prime and semiprime ideals
References
Index