### PR TITLE
Travis: test with 4.8, 4.9, 4.10; don't test 32bit, clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,13 @@ addons:
   apt_packages:
     - libgmp-dev
     - libreadline-dev
-    - libgmp-dev:i386
-    - libreadline-dev:i386
-    - gcc-multilib
-    - g++-multilib
+    - zlib1g-dev
 
 matrix:
   include:
-    - env: CFLAGS="-O2" CC=clang CXX=clang++
-      compiler: clang
-    - env: CFLAGS="-O2"
-      compiler: gcc
-    - env: ABI=32
+    - env: GAPBRANCH=master
+    - env: GAPBRANCH=stable-4.10
+    - env: GAPBRANCH=stable-4.9
 
 branches:
   only:


### PR DESCRIPTION
This package does not contain kernel code, so there seems to be no good reason
to test with different C compilers, or in a 32bit environment.

Instead, let's test against various GAP stable branches, as this package
claims to be compatible with GAP >= 4.8.

(I am not actually sure the 4.8 test will work; we'll see)