### PR TITLE
Avoid declaring and using attribute 'Matrix'

### DIFF
--- a/lib/cycleset.gd
+++ b/lib/cycleset.gd
@@ -29,7 +29,7 @@ DeclareOperation("CycleSetCycle", [ IsCycleSet, IsInt, IsInt ]);
 DeclareAttribute("AsList", IsCycleSet);
 DeclareAttribute("Enumerator", IsCycleSet);
 DeclareAttribute("Permutations", IsCycleSet);
-DeclareAttribute("Matrix", IsCycleSet);
+DeclareAttribute("MatrixOfCycleSet", IsCycleSet);
 
 
 ### Dynamical cocycles and extensions

--- a/lib/cycleset.gi
+++ b/lib/cycleset.gi
@@ -18,11 +18,13 @@ function(matrix)
   fam!.CycleSet := obj;
 
   SetSize(obj, Size(matrix)); 
-  SetMatrix(obj, matrix);
+  SetMatrixOfCycleSet(obj, matrix);
   SetPermutations(obj, List([1..Size(obj)], x->PermList(matrix[x])));
 
   return obj;
 end);
+
+InstallOtherMethod(Matrix, [ IsCycleSet and HasMatrixOfCycleSet ], MatrixOfCycleSet);
 
 InstallMethod(ViewObj,
   "for a cycle set",
@@ -36,7 +38,7 @@ InstallMethod(PrintObj,
   [ IsCycleSet ],
   function(obj)
   if Size(obj) < 6 then
-    Print("CycleSet(", Matrix(obj), ")");
+    Print("CycleSet(", MatrixOfCycleSet(obj), ")");
   else
     Print("<A cycle set of size ", Size(obj), ">");
   fi;
@@ -86,7 +88,7 @@ InstallMethod( \*,
     function( x, y )
     local fam;
     fam := FamilyObj(x);
-    return CycleSetElmConstructor(fam!.CycleSet, Matrix(fam!.CycleSet)[x![1]][y![1]]);
+    return CycleSetElmConstructor(fam!.CycleSet, MatrixOfCycleSet(fam!.CycleSet)[x![1],y![1]]);
 end);
 
 InstallMethod(Permutations2CycleSet, "for a list of permutations", [ IsList ], 
@@ -147,12 +149,12 @@ InstallOtherMethod(IsSquareFree,
   return true;
 end);
 
-InstallOtherMethod(Permutations,
-  "for cycle sets",
-  [ IsCycleSet ],
-  function(obj)
-  return List([1..Size(obj!.matrix)], i->PermList(obj!.matrix[i]));
-end);
+#InstallOtherMethod(Permutations,
+#  "for cycle sets",
+#  [ IsCycleSet ],
+#  function(obj)
+#  return List([1..Size(obj!.matrix)], i->PermList(obj!.matrix[i]));
+#end);
 
 ### This function converts a cycle set into a set-theoretical solution
 ### EXAMPLE:
@@ -160,11 +162,13 @@ end);
 ### gap> r := CycleSet2YB(c);;
 InstallMethod(CycleSet2YB, "for cycle sets", [ IsCycleSet ],
 function(obj)
-  local lperms, rperms, x, y;
+  local mat, lperms, rperms, x, y;
+  mat := MatrixOfCycleSet(obj);
+  perms := Permutations(obj);
   lperms := NullMat(Size(obj), Size(obj));
   for x in [1..Size(obj)] do
     for y in [1..Size(obj)] do
-      lperms[x][y] := Matrix(obj)[x^Inverse(PermList(Matrix(obj)[y]))][y];
+      lperms[x][y] := mat[x/perms[y],y];
     od;
   od;
   rperms := List(Permutations(obj), x->ListPerm(Inverse(x), Size(obj)));
@@ -721,10 +725,11 @@ end);
 ### returns true if the map f:f(x)=x>x is bijective
 InstallOtherMethod(IsNonDegenerate, "for a cycle set", [ IsCycleSet ],
 function(obj)
-  local i,p;
+  local mat,i,p;
+  mat := MatrixOfCycleSet(obj);
   p := [];
   for i in [1..Size(obj)] do
-    p[i] := Matrix(obj)[i][i];
+    p[i] := mat[i,i];
   od;
   if PermList(p) <> fail then
     return true;

--- a/lib/rack.gd
+++ b/lib/rack.gd
@@ -11,12 +11,11 @@ BindGlobal("RackType", NewType(CollectionsFamily( RackElmFamily ), IsRack and Is
 #DeclareGlobalVariable("RackType");
 
 ### To create/recognize racks 
-DeclareGlobalFunction("IsRackMatrix");
 DeclareOperation("Rack", [IsList]);
 DeclareAttribute("Rack2YB", IsRack);
 DeclareAttribute("AsList", IsRack);
 DeclareAttribute("Enumerator", IsRack);
 
 DeclareAttribute("Permutations", IsRack);
-DeclareAttribute("Matrix", IsRack);
+DeclareAttribute("MatrixOfRack", IsRack);
 

--- a/lib/rack.gi
+++ b/lib/rack.gi
@@ -16,11 +16,13 @@ function(matrix)
   fam!.Rack := obj;
 
   SetSize(obj, Size(matrix)); 
-  SetMatrix(obj, matrix);
+  SetMatrixOfRack(obj, matrix);
   SetPermutations(obj, List([1..Size(obj)], x->PermList(matrix[x])));
 
   return obj;
 end);
+
+InstallOtherMethod(Matrix, [ IsRack and HasMatrixOfRack ], MatrixOfRack);
 
 InstallMethod(ViewObj,
   "for a rack",
@@ -33,7 +35,7 @@ InstallMethod(PrintObj,
   "for a rack", 
   [ IsRack ],
   function(obj)
-  Print( "Rack( ", Matrix(obj), " )");
+  Print( "Rack( ", MatrixOfRack(obj), " )");
 end);
 
 InstallMethod(Enumerator,
@@ -73,11 +75,11 @@ InstallMethod( \*,
     function( x, y )
     local fam;
     fam := FamilyObj(x);
-    return RackElmConstructor(fam!.Rack, Matrix(fam!.Rack)[x![1]][y![1]]);
+    return RackElmConstructor(fam!.Rack, MatrixOfRack(fam!.Rack)[x![1],y![1]]);
 end);
 
 InstallMethod(Rack2YB, "for a rack", [ IsRack ], 
 function(obj)
-  return YB(Matrix(obj), List([1..Size(obj)], x->[1..Size(obj)]));
+  return YB(MatrixOfRack(obj), List([1..Size(obj)], x->[1..Size(obj)]));
 end);
 


### PR DESCRIPTION
Instead, introduce two attributes MatrixOfRack and MatrixOfCycleSet,
and provide convenience methods for Matrix that delegate to the two.

This way, Matrix is freed up to become an operation in GAP 4.12.

Also optimize CycleSet2YB a bit.