### PR TITLE
Don't use undocumented InstallGlobalFunction argument

### DIFF
--- a/lib/ybe.gi
+++ b/lib/ybe.gi
@@ -231,7 +231,6 @@ InstallMethod(YB2CycleSet,
 end);
 
 InstallGlobalFunction(YB_xy,
-  "for a set-theoretical solution",
   function(obj, x, y)
   return [LMatrix(obj)[x][y], RMatrix(obj)[y][x]];
   #return [obj!.l_actions[x][y], obj!.r_actions[y][x]];


### PR DESCRIPTION
It's not just undocumented, it is also not used, and never was.

This code will otherwise produce a warning in GAP 4.12, see https://github.com/gap-system/gap/pull/3694