### PR TITLE
Compress data files in releases

### DIFF
--- a/.release
+++ b/.release
@@ -2,3 +2,6 @@
 # This file is executed by the `release` script from
 # https://github.com/gap-system/ReleaseTools
 rm -rf .travis.yml .codecov.yml
+
+# compress data files
+gzip -9 data/*


### PR DESCRIPTION
In YangBaxter-0.8.0, the data directory takes up 367 MB; if one
uses `gzip -9` to compress each data file, this goes down to just
54 MB. The resulting compressed files are also *faster* to load,
as the decompression (which GAP performs transparently) is faster
than typical hard disks.