### PR TITLE
Fix errors and typos in examples; regenerate tests

### DIFF
--- a/lib/ybe.gd
+++ b/lib/ybe.gd
@@ -15,7 +15,7 @@ DeclareOperation("InverseYB", [IsYB]);
 #! Given the table with $r(x,y)$ in the position $(x,y)$ find the corresponding $r$  
 #! @ExampleSession
 #! gap> l := Table(SmallIYB(4,13));;
-#! gap> t := Table2YB(l);
+#! gap> t := Table2YB(l);;
 #! gap> IdCycleSet(YB2CycleSet(t));
 #! [ 4, 13 ]
 #! @EndExampleSession
@@ -107,6 +107,7 @@ DeclareAttribute("RMatrix", IsYB);
 #! gap> yb := SmallIYB(3,2);;
 #! gap> Table(yb);
 #! [ [ [ 1, 1 ], [ 2, 1 ], [ 3, 2 ] ], [ [ 1, 2 ], [ 2, 2 ], [ 3, 1 ] ], [ [ 2, 3 ], [ 1, 3 ], [ 3, 3 ] ] ]
+#! @EndExampleSession
 DeclareAttribute("Table", IsYB);
 
 DeclareAttribute("YBPermutationGroup", IsYB);
@@ -174,9 +175,9 @@ DeclareOperation("DehornoyRepresentationOfStructureGroup", [ IsYB, IsObject ]);
 #! @Returns the identification number of <A>obj</A>
 #! @Description
 #! 
-#! @ExampleSessiong
-#! gap> cs := SmallCycleg1Set(5,10);;
-#! gap> IdCycleSet(cs);1
+#! @ExampleSession
+#! gap> cs := SmallCycleSet(5,10);;
+#! gap> IdCycleSet(cs);
 #! [ 5, 10 ]
 #! gap> cs := SmallCycleSet(4,3);;
 #! gap> yb := CycleSet2YB(cs);;

--- a/tst/yangbaxter02.tst
+++ b/tst/yangbaxter02.tst
@@ -23,7 +23,13 @@ gap> rg := SmallRing(8,20);;
 gap> IsJacobsonRadical(rg);
 false
 
-# doc/_Chapter_Algebraic_Properties_of_Braces.xml:61-71
+# doc/_Chapter_Algebraic_Properties_of_Braces.xml:61-66
+gap> l := Table(SmallIYB(4,13));;
+gap> t := Table2YB(l);;
+gap> IdCycleSet(YB2CycleSet(t));
+[ 4, 13 ]
+
+# doc/_Chapter_Algebraic_Properties_of_Braces.xml:79-89
 gap> cs := SmallCycleSet(4,13);;
 gap> yb := CycleSet2YB(cs);;
 gap> Permutations(yb);
@@ -34,20 +40,18 @@ gap> Evaluate(yb, [1,2]);
 gap> Evaluate(yb, [1,3]); 
 [ 4, 2 ]
 
-# doc/_Chapter_Algebraic_Properties_of_Braces.xml:87-92
+# doc/_Chapter_Algebraic_Properties_of_Braces.xml:105-110
 gap> yb := LyubashenkoYB(4, (1,2),(3,4));
 <A set-theoretical solution of size 4>
 gap> Permutations(last);
 [ [ (1,2), (1,2), (1,2), (1,2) ], [ (3,4), (3,4), (3,4), (3,4) ] ]
 
-# doc/_Chapter_Algebraic_Properties_of_Braces.xml:115-131
+# doc/_Chapter_Algebraic_Properties_of_Braces.xml:133-137
 gap> yb := SmallIYB(3,2);;
 gap> Table(yb);
 [ [ [ 1, 1 ], [ 2, 1 ], [ 3, 2 ] ], [ [ 1, 2 ], [ 2, 2 ], [ 3, 1 ] ], [ [ 2, 3 ], [ 1, 3 ], [ 3, 3 ] ] ]
-@Arguments obj
-@Returns The class of an involutive solution
-@Description
-@ExampleSession
+
+# doc/_Chapter_Algebraic_Properties_of_Braces.xml:149-158
 gap> cs := SmallCycleSet(4,13);;
 gap> yb := CycleSet2YB(cs);;
 gap> DehornoyClass(yb);
@@ -57,7 +61,7 @@ gap> yb := CycleSet2YB(cs);;
 gap> DehornoyClass(yb);
 4
 
-# doc/_Chapter_Algebraic_Properties_of_Braces.xml:144-169
+# doc/_Chapter_Algebraic_Properties_of_Braces.xml:171-196
 gap> cs := SmallCycleSet(4,13);;
 gap> yb := CycleSet2YB(cs);;
 gap> Permutations(yb);
@@ -83,7 +87,7 @@ true
 gap> x3*x1=x4*x3;
 true
 
-# doc/_Chapter_Algebraic_Properties_of_Braces.xml:182-190
+# doc/_Chapter_Algebraic_Properties_of_Braces.xml:209-217
 gap> cs := SmallCycleSet(5,10);;
 gap> IdCycleSet(cs);
 [ 5, 10 ]
@@ -92,7 +96,7 @@ gap> yb := CycleSet2YB(cs);;
 gap> IdYB(yb);
 [ 4, 3 ]
 
-# doc/_Chapter_Algebraic_Properties_of_Braces.xml:211-222
+# doc/_Chapter_Algebraic_Properties_of_Braces.xml:238-249
 gap> yb := SmallIYB(5,86);;
 gap> gr := LinearRepresentationOfStructureGroup(yb);;
 gap> gens := GeneratorsOfGroup(gr);;


### PR DESCRIPTION
@vendramin I've fixed the tests - there were multiple errors in GAPDoc markup, typos like spurious inputs in a wrong window, and not suppressed with `;;` outputs. It took a few iterations of CI to polish tests. Better to submit PRs instead of commit to the master branch - then you can see problems BEFORE they go into the repository, and not after.