### PR TITLE
Add START_TEST/STOP_TEST to .tst files

### DIFF
--- a/tst/testextra/example23.tst
+++ b/tst/testextra/example23.tst
@@ -1,3 +1,6 @@
+#
+gap> START_TEST("example23.tst");
+
 # Example 2.3
 gap> br := SmallSkewbrace(6,1);;
 gap> IsTrivialSkewbrace(br);
@@ -11,3 +14,5 @@ gap> StructureDescription(mul);
 gap> Socle(br);
 <brace of size 1>
 
+#
+gap> STOP_TEST("example23.tst", 1);

--- a/tst/testextra/example24.tst
+++ b/tst/testextra/example24.tst
@@ -1,3 +1,6 @@
+#
+gap> START_TEST("example24.tst");
+
 # Example 2.4
 gap> br := SmallBrace(8,5);;
 gap> add := UnderlyingAdditiveGroup(br);;
@@ -27,3 +30,5 @@ gap> List(ideals, IdBrace);
 gap> List(ideals, x->IdBrace(br/x));
 [ [ 8, 5 ], [ 4, 2 ], [ 2, 1 ], [ 1, 1 ] ]
 
+#
+gap> STOP_TEST("example24.tst", 1);

--- a/tst/testextra/example25.tst
+++ b/tst/testextra/example25.tst
@@ -1,3 +1,6 @@
+#
+gap> START_TEST("example25.tst");
+
 # Example 2.5
 gap> br := SmallBrace(6,2);;
 gap> add := UnderlyingAdditiveGroup(br);;
@@ -28,3 +31,5 @@ gap> List(left_ideals, x->IsIdeal(br, x));
 [ true, true, true, true ]
 gap> 
 
+#
+gap> STOP_TEST("example25.tst", 1);

--- a/tst/testextra/example26.tst
+++ b/tst/testextra/example26.tst
@@ -1,3 +1,6 @@
+#
+gap> START_TEST("example26.tst");
+
 # Example 3.5
 gap> br := SmallBrace(6,1);;
 gap> IsTrivialSkewbrace(br);
@@ -20,3 +23,6 @@ gap> List(left_ideals, x->IsIdeal(br, x));
 [ true, false, true, true ]
 gap> SortedList(List(Ideals(br),Size));
 [ 1, 3, 6 ]
+
+#
+gap> STOP_TEST("example26.tst", 1);

--- a/tst/testextra/example27.tst
+++ b/tst/testextra/example27.tst
@@ -1,3 +1,6 @@
+#
+gap> START_TEST("example27.tst");
+
 # Example 3.7
 gap> br := SmallBrace(8,18);;
 gap> ideals := Ideals(br);;
@@ -6,3 +9,5 @@ gap> SortedList(List(ideals, IdBrace));
 gap> Star(AsIdeal(br, br), ideals[2]);
 [ <()>, <(1,2)(3,4)(5,6)(7,8)> ]
 
+#
+gap> STOP_TEST("example27.tst", 1);

--- a/tst/testextra/example31.tst
+++ b/tst/testextra/example31.tst
@@ -1,3 +1,6 @@
+#
+gap> START_TEST("example31.tst");
+
 # Example 3.1
 gap> br := SmallSkewbrace(36,191);;
 gap> left_series := LeftSeries(br);;
@@ -6,3 +9,5 @@ gap> List(left_series, IdSkewbrace);
 gap> List(left_series, x->IsIdeal(br, x));
 [ true, true, false ]
 
+#
+gap> STOP_TEST("example31.tst", 1);

--- a/tst/testextra/example32.tst
+++ b/tst/testextra/example32.tst
@@ -1,6 +1,7 @@
+#
+gap> START_TEST("example32.tst");
+
 # Example 3.2
-gap> INFO_PERFORMANCE_CURRENT := InfoLevel(InfoPerformance);;
-gap> SetInfoLevel(InfoPerformance,0);
 gap> br := SmallBrace(16,73);;
 gap> ideals := Ideals(br);;
 gap> SortedList(List(ideals, IdBrace));
@@ -11,4 +12,6 @@ gap> Star(x, x);
 [ <()>, <( 1, 2)( 3, 4)( 5, 6)( 7, 8)( 9,10)(11,12)(13,14)(15,16)> ]
 gap> IsIdeal(br, last);
 false
-gap> SetInfoLevel(InfoPerformance, INFO_PERFORMANCE_CURRENT);
+
+#
+gap> STOP_TEST("example32.tst", 1);

--- a/tst/testextra/example33.tst
+++ b/tst/testextra/example33.tst
@@ -1,3 +1,6 @@
+#
+gap> START_TEST("example33.tst");
+
 # Example 3.3
 gap> br := SmallSkewbrace(12,22);;
 gap> StructureDescription(UnderlyingAdditiveGroup(br));
@@ -11,3 +14,5 @@ gap> LeftSeries(br);
 gap> RightSeries(br);
 [ <skew brace of size 12> ]
 
+#
+gap> STOP_TEST("example33.tst", 1);

--- a/tst/testextra/example34.tst
+++ b/tst/testextra/example34.tst
@@ -1,3 +1,6 @@
+#
+gap> START_TEST("example34.tst");
+
 # Example 3.4
 gap> br := SmallSkewbrace(24,50);;
 gap> add := UnderlyingAdditiveGroup(br);;
@@ -13,3 +16,5 @@ gap> RightSeries(br);
 gap> Socle(br);
 <brace of size 2>
 
+#
+gap> STOP_TEST("example34.tst", 1);

--- a/tst/testextra/example42.tst
+++ b/tst/testextra/example42.tst
@@ -1,3 +1,6 @@
+#
+gap> START_TEST("example42.tst");
+
 # Example 4.2
 gap> br := SmallSkewbrace(24,708);;
 gap> IsPrimeBrace(br);
@@ -5,3 +8,5 @@ true
 gap> IsSimple(br);
 false
 
+#
+gap> STOP_TEST("example42.tst", 1);

--- a/tst/testextra/example429.tst
+++ b/tst/testextra/example429.tst
@@ -1,3 +1,6 @@
+#
+gap> START_TEST("example429.tst");
+
 # Example 4.29
 gap> br := SmallSkewbrace(6,2);;
 gap> IdBrace(WedderburnRadical(br));
@@ -6,3 +9,6 @@ gap> BaerRadical(br);
 <skew brace of size 6>
 
 	 
+
+#
+gap> STOP_TEST("example429.tst", 1);

--- a/tst/testextra/example47.tst
+++ b/tst/testextra/example47.tst
@@ -1,3 +1,6 @@
+#
+gap> START_TEST("example47.tst");
+
 # Example 4.7
 gap> br := SmallSkewbrace(12,22);;
 gap> IsSimple(br);
@@ -12,3 +15,5 @@ false
 gap> IsSemiprime(prod);
 true
 
+#
+gap> STOP_TEST("example47.tst", 1);

--- a/tst/testextra/example52.tst
+++ b/tst/testextra/example52.tst
@@ -1,3 +1,6 @@
+#
+gap> START_TEST("example52.tst");
+
 # Example 5.2
 gap> br := SmallBrace(48,396);;
 gap> solvable_series := SolvableSeries(br);;
@@ -6,3 +9,5 @@ gap> List(solvable_series, IdBrace);
 gap> List(solvable_series, x->IsIdeal(br, x));
 [ true, true, false, true, true ]
 
+#
+gap> STOP_TEST("example52.tst", 1);


### PR DESCRIPTION
These functions perform various setup, like adjusting assertion and info
levels, triggering garbage collections, and so on. The motivation for doing
this now is that they also (temporarily) set InfoPerformance to 0, which
prevents various issues caused by differences across GAP versions.

We can thus also remove some code doing this from example32.tst.