### PR TITLE
Fix tests with latest GAP

### DIFF
--- a/lib/skew.gi
+++ b/lib/skew.gi
@@ -901,7 +901,7 @@ InstallMethod(DirectProductSkewbraces, "for two skew braces", [IsSkewbrace, IsSk
 
   l := List(Cartesian(obj1,obj2), u->[u]);
 
-  add := AsList(DirectProduct(UnderlyingAdditiveGroup(obj1),UnderlyingAdditiveGroup(obj2)));
+  add := AsSet(DirectProduct(UnderlyingAdditiveGroup(obj1),UnderlyingAdditiveGroup(obj2)));
   mul := NullMat(Size(l),Size(l));
 
   for u in l do


### PR DESCRIPTION
In the latest GAP development version, the order of elements returned by AsList changed if the input is a permutation group. Switch to AsSet to get a guaranteed, fixed order.

Resolves #88 

