### PR TITLE
Use 'gzip -n' for compression during release

### DIFF
--- a/.release
+++ b/.release
@@ -3,4 +3,4 @@
 # https://github.com/gap-system/ReleaseTools
 
 # compress data files
-gzip -9 data/*
+gzip -9 -n data/*


### PR DESCRIPTION
This option ensures no timestamps are put into the .gz files. That is
important for reproducible builds and also allows tooling used by e.g.
computer admins to notice that those files did not actually change in an
upgrade.
