### PR TITLE
 Add error message in `IsIndecomposable` for non-involutive solutions

### DIFF
--- a/lib/ybe.gi
+++ b/lib/ybe.gi
@@ -774,7 +774,7 @@ InstallMethod(IsIndecomposable,
   [ IsYB ],
   function(obj)
     if not IsInvolutive(obj) then
-      return fail;
+      Error("the solutions of the YBE is not involutive");
     else
       return IsTransitive(IYBGroup(obj), [1..Size(obj)]);
     fi;


### PR DESCRIPTION
This PR adds a specific error message in the `IsIndecomposable` function when invoked with a non-involutive solution. Previously, the function triggered a generic error: `Error, Method for a property did not return true or false`.